### PR TITLE
Externalizing deregistration_delay, health_check_matcher and health_check_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused. | string | `30` | no |
 | enable\_cross\_zone\_load\_balancing | Indicates whether cross zone load balancing should be enabled in application load balancers. | string | `false` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | string | `false` | no |
 | enable\_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | enable\_http2 | Indicates whether HTTP/2 is enabled in application load balancers. | string | `true` | no |
 | extra\_ssl\_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). | list | `<list>` | no |
 | extra\_ssl\_certs\_count | A manually provided count/length of the extra_ssl_certs list of maps since the list cannot be computed. | string | `0` | no |
+| health\_check\_matcher | The HTTP response codes to indicate a healthy check. | string | `200-399` | no |
+| health\_check\_path | The destination for the health check request. | string | `/` | no |
 | http\_tcp\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, protocol. Optional key/values: target_group_index (defaults to 0) | list | `<list>` | no |
 | http\_tcp\_listeners\_count | A manually provided count/length of the http_tcp_listeners list of maps since the list cannot be computed. | string | `0` | no |
 | https\_listeners | A list of maps describing the HTTPS listeners for this ALB. Required key/values: port, certificate_arn. Optional key/values: ssl_policy (defaults to ELBSecurityPolicy-2016-08), target_group_index (defaults to 0) | list | `<list>` | no |

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -25,7 +25,7 @@ resource "aws_lb_target_group" "main_no_logs" {
   vpc_id               = "${var.vpc_id}"
   port                 = "${lookup(var.target_groups[count.index], "backend_port")}"
   protocol             = "${upper(lookup(var.target_groups[count.index], "backend_protocol"))}"
-  deregistration_delay = "${lookup(var.target_groups[count.index], "deregistration_delay", lookup(local.target_groups_defaults, "deregistration_delay"))}"
+  deregistration_delay = "${var.deregistration_delay}"
   target_type          = "${lookup(var.target_groups[count.index], "target_type", lookup(local.target_groups_defaults, "target_type"))}"
   slow_start           = "${lookup(var.target_groups[count.index], "slow_start", lookup(local.target_groups_defaults, "slow_start"))}"
 

--- a/alb_no_logs.tf
+++ b/alb_no_logs.tf
@@ -31,13 +31,13 @@ resource "aws_lb_target_group" "main_no_logs" {
 
   health_check {
     interval            = "${lookup(var.target_groups[count.index], "health_check_interval", lookup(local.target_groups_defaults, "health_check_interval"))}"
-    path                = "${lookup(var.target_groups[count.index], "health_check_path", lookup(local.target_groups_defaults, "health_check_path"))}"
+    path                = "${var.health_check_path}"
     port                = "${lookup(var.target_groups[count.index], "health_check_port", lookup(local.target_groups_defaults, "health_check_port"))}"
     healthy_threshold   = "${lookup(var.target_groups[count.index], "health_check_healthy_threshold", lookup(local.target_groups_defaults, "health_check_healthy_threshold"))}"
     unhealthy_threshold = "${lookup(var.target_groups[count.index], "health_check_unhealthy_threshold", lookup(local.target_groups_defaults, "health_check_unhealthy_threshold"))}"
     timeout             = "${lookup(var.target_groups[count.index], "health_check_timeout", lookup(local.target_groups_defaults, "health_check_timeout"))}"
     protocol            = "${upper(lookup(var.target_groups[count.index], "healthcheck_protocol", lookup(var.target_groups[count.index], "backend_protocol")))}"
-    matcher             = "${lookup(var.target_groups[count.index], "health_check_matcher", lookup(local.target_groups_defaults, "health_check_matcher"))}"
+    matcher             = "${var.health_check_matcher}"
   }
 
   stickiness {

--- a/alb_w_logs.tf
+++ b/alb_w_logs.tf
@@ -31,19 +31,19 @@ resource "aws_lb_target_group" "main" {
   vpc_id               = "${var.vpc_id}"
   port                 = "${lookup(var.target_groups[count.index], "backend_port")}"
   protocol             = "${upper(lookup(var.target_groups[count.index], "backend_protocol"))}"
-  deregistration_delay = "${lookup(var.target_groups[count.index], "deregistration_delay", lookup(local.target_groups_defaults, "deregistration_delay"))}"
+  deregistration_delay = "${var.deregistration_delay}"
   target_type          = "${lookup(var.target_groups[count.index], "target_type", lookup(local.target_groups_defaults, "target_type"))}"
   slow_start           = "${lookup(var.target_groups[count.index], "slow_start", lookup(local.target_groups_defaults, "slow_start"))}"
 
   health_check {
     interval            = "${lookup(var.target_groups[count.index], "health_check_interval", lookup(local.target_groups_defaults, "health_check_interval"))}"
-    path                = "${lookup(var.target_groups[count.index], "health_check_path", lookup(local.target_groups_defaults, "health_check_path"))}"
+    path                = "${var.health_check_path}"
     port                = "${lookup(var.target_groups[count.index], "health_check_port", lookup(local.target_groups_defaults, "health_check_port"))}"
     healthy_threshold   = "${lookup(var.target_groups[count.index], "health_check_healthy_threshold", lookup(local.target_groups_defaults, "health_check_healthy_threshold"))}"
     unhealthy_threshold = "${lookup(var.target_groups[count.index], "health_check_unhealthy_threshold", lookup(local.target_groups_defaults, "health_check_unhealthy_threshold"))}"
     timeout             = "${lookup(var.target_groups[count.index], "health_check_timeout", lookup(local.target_groups_defaults, "health_check_timeout"))}"
     protocol            = "${upper(lookup(var.target_groups[count.index], "healthcheck_protocol", lookup(var.target_groups[count.index], "backend_protocol")))}"
-    matcher             = "${lookup(var.target_groups[count.index], "health_check_matcher", lookup(local.target_groups_defaults, "health_check_matcher"))}"
+    matcher             = "${var.health_check_matcher}"
   }
 
   stickiness {

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,6 @@
 locals {
   target_groups_default_configs = {
     cookie_duration                  = 86400
-    deregistration_delay             = 300
     health_check_interval            = 10
     health_check_healthy_threshold   = 3
     health_check_path                = "/"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "deregistration_delay" {
+  description = "The amount of time to wait in seconds before changing the state of a deregistering target to unused."
+  default     = "30"
+}
+
 variable "enable_deletion_protection" {
   description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
   default     = false
@@ -22,6 +27,16 @@ variable "extra_ssl_certs" {
 variable "extra_ssl_certs_count" {
   description = "A manually provided count/length of the extra_ssl_certs list of maps since the list cannot be computed."
   default     = 0
+}
+
+variable "health_check_path" {
+  description = "The destination for the health check request."
+  default     = "/"
+}
+
+variable "health_check_matcher" {
+  description = "The HTTP response codes to indicate a healthy check."
+  default     = "200-399"
 }
 
 variable "https_listeners" {
@@ -129,11 +144,6 @@ variable "target_groups_count" {
 variable "target_groups_defaults" {
   description = "Default values for target groups as defined by the list of maps."
   default     = {}
-}
-
-variable "deregistration_delay" {
-  description = "The amount of time to wait in seconds before changing the state of a deregistering target to unused."
-  default     = "30"
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,11 @@ variable "target_groups_defaults" {
   default     = {}
 }
 
+variable "deregistration_delay" {
+  description = "The amount of time to wait in seconds before changing the state of a deregistering target to unused."
+  default     = "30"
+}
+
 variable "vpc_id" {
   description = "VPC id where the load balancer and other resources will be deployed."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,14 +29,14 @@ variable "extra_ssl_certs_count" {
   default     = 0
 }
 
-variable "health_check_path" {
-  description = "The destination for the health check request."
-  default     = "/"
-}
-
 variable "health_check_matcher" {
   description = "The HTTP response codes to indicate a healthy check."
   default     = "200-399"
+}
+
+variable "health_check_path" {
+  description = "The destination for the health check request."
+  default     = "/"
 }
 
 variable "https_listeners" {


### PR DESCRIPTION
# PR - Externalizing "deregistration_delay", "health_check_matcher" and "health_check_path"

## Description
Externalizing "deregistration_delay", "health_check_matcher" and "health_check_path" to offer the possibility to customize those values.

Please explain the changes you made here and link to any relevant issues.

### Checklist

* [Y] `terraform fmt` and `terraform validate` both work from the root and `examples/alb_test_fixture` directories (look in CI for an example)
* [Y] Tests for the changes have been added and passing (for bug fixes/features)
* [Y] Test results are pasted in this PR (in lieu of CI)
* [Y] Docs have been added/updated (for bug fixes/features)
* [N] Any breaking changes are noted in the description above
